### PR TITLE
Close response body, when done.

### DIFF
--- a/kinesis.go
+++ b/kinesis.go
@@ -111,6 +111,7 @@ func (kinesis *Kinesis) query(params map[string]string, data interface{}, resp i
   if err != nil {
     return err
   }
+  defer response.Body.Close()
 
   if response.StatusCode != 200 {
     return buildError(response)


### PR DESCRIPTION
My application, I noticed, started to run out of memory when making high number of `PutRecord` requests per second.

Turns out `response.Body.Close()` was missing, which caused a high speed resource leak in my app.
I confirmed in Go [net/http docs](http://golang.org/pkg/net/http/#Client.Do) that it is indeed required of callers to close the response body.
