### PR TITLE
Fix variable naming in SequenceNumberRange struct

### DIFF
--- a/kinesis.go
+++ b/kinesis.go
@@ -215,8 +215,8 @@ type DescribeStreamShards struct {
   }
   ParentShardId             string
   SequenceNumberRange struct {
-    EndingHashKey           string
-    StartingHashKey         string
+    EndingSequenceNumber    string
+    StartingSequenceNumber  string
   }
   ShardId                   string
 }


### PR DESCRIPTION
Fixes the DescribeStreamShards.SequenceNumberRange struct to match the amazon Kinesis API
http://docs.aws.amazon.com/kinesis/latest/APIReference/API_SequenceNumberRange.html
