### PR TITLE
Converts the base64 encoded data from []byte to string.

### DIFF
--- a/kinesis.go
+++ b/kinesis.go
@@ -81,7 +81,7 @@ func (f *RequestArgs) AddData(value []byte) {
   enc := base64.StdEncoding
   buf := make([]byte, enc.EncodedLen(len(value)))
   enc.Encode(buf, value)
-  f.params["Data"] = buf
+  f.params["Data"] = string(buf)
 }
 
 // Error represent error from Kinesis API


### PR DESCRIPTION
Per http://golang.org/pkg/encoding/json/ "Array and slice values encode as JSON arrays, except that []byte encodes as a base64-encoded string, and a nil slice encodes as the null JSON object." This meant that the Data attribute was being base64 encoded twice. Once explicitly in the PutData method, and then again implicitly when encoded into json inside the kinesis.query method.
