### PR TITLE
Change the constructor to use Auth

### DIFF
--- a/examples/example.go
+++ b/examples/example.go
@@ -41,7 +41,7 @@ func main() {
 
 	streamName := "test"
 	// set env variables AWS_ACCESS_KEY and AWS_SECRET_KEY AWS_REGION_NAME
-	ksis := kinesis.New("", "", kinesis.Region{})
+	ksis := kinesis.New(&kinesis.Auth{}, kinesis.Region{})
 
 	err := ksis.CreateStream(streamName, 2)
 	if err != nil {

--- a/kinesis-cli/kinesis-cli.go
+++ b/kinesis-cli/kinesis-cli.go
@@ -232,7 +232,7 @@ func bigIntFromStr(s string, base int) *big.Int {
 
 func newClient() kinesis.KinesisClient {
 	// NOTE: kinesis.client.go sets auth from env when empty.
-	return kinesis.New("", "", kinesis.Region{})
+	return kinesis.New(&kinesis.Auth{}, kinesis.Region{})
 }
 
 func askForShardStartHash(streamName, shardId string) string {

--- a/kinesis.go
+++ b/kinesis.go
@@ -46,13 +46,9 @@ type KinesisClient interface {
 	SplitShard(args *RequestArgs) error
 }
 
-// Initialize new client for AWS Kinesis
-func New(access_key string, secret_key string, region Region) *Kinesis {
-	keys := &Auth{
-		AccessKey: access_key,
-		SecretKey: secret_key,
-	}
-	return &Kinesis{client: NewClient(keys), Version: "20131202", Region: GetRegion(region)}
+// New returns an initialized AWS Kinesis client
+func New(auth *Auth, region Region) *Kinesis {
+	return &Kinesis{client: NewClient(auth), Version: "20131202", Region: GetRegion(region)}
 }
 
 // Create params object for request

--- a/kinesis.go
+++ b/kinesis.go
@@ -1,4 +1,4 @@
-// Package provide GOlang API for http://aws.amazon.com/kinesis/
+// Package kinesis provide GOlang API for http://aws.amazon.com/kinesis/
 package kinesis
 
 import (
@@ -21,9 +21,12 @@ type Region struct {
 	Name string
 }
 
-var USEast = Region{"us-east-1"}
-var USWest2 = Region{"us-west-2"}
-var EUWest = Region{"eu-west-1"}
+var (
+	USEast    = Region{"us-east-1"}
+	USWest2   = Region{"us-west-2"}
+	EUWest    = Region{"eu-west-1"}
+	EUCentral = Region{"eu-central-1"}
+)
 
 // Structure for kinesis client
 type Kinesis struct {

--- a/kinesis_test.go
+++ b/kinesis_test.go
@@ -5,7 +5,12 @@ import "testing"
 // Trivial test to make sure that Kinesis implements KinesisClient.
 func TestInterfaceIsImplemented(t *testing.T) {
 	var client KinesisClient
-	client = New("BAD_ACCESS_KEY", "BAD_SECRET_KEY", USEast)
+	auth := &Auth{
+		AccessKey: "BAD_ACCESS_KEY",
+		SecretKey: "BAD_SECRET_KEY",
+	}
+
+	client = New(auth, USEast)
 	if client == nil {
 		t.Error("Client is nil")
 	}


### PR DESCRIPTION
This change allows to pass in a IAM token using the Auth object
instead of passing access key id and secret key params directly.

See #19 