### PR TITLE
Add missing regions and constant numbering

### DIFF
--- a/kinesis.go
+++ b/kinesis.go
@@ -13,19 +13,20 @@ const (
 	ACTION_KEY = "Action"
 )
 
-var (
-	timeNow = time.Now
-)
-
 type Region struct {
 	Name string
 }
 
 var (
-	USEast    = Region{"us-east-1"}
-	USWest2   = Region{"us-west-2"}
-	EUWest    = Region{"eu-west-1"}
-	EUCentral = Region{"eu-central-1"}
+	USEast1      = Region{"us-east-1"}
+	USWest2      = Region{"us-west-2"}
+	EUWest1      = Region{"eu-west-1"}
+	EUCentral1   = Region{"eu-central-1"}
+	APSouthEast1 = Region{"ap-southeast-1"}
+	APSouthEast2 = Region{"ap-southeast-2"}
+	APNortheast1 = Region{"ap-northeast-1"}
+
+	timeNow = time.Now
 )
 
 // Structure for kinesis client

--- a/kinesis_test.go
+++ b/kinesis_test.go
@@ -10,21 +10,21 @@ func TestInterfaceIsImplemented(t *testing.T) {
 		SecretKey: "BAD_SECRET_KEY",
 	}
 
-	client = New(auth, USEast)
+	client = New(auth, USEast1)
 	if client == nil {
 		t.Error("Client is nil")
 	}
 }
 
 func TestRegions(t *testing.T) {
-	if EUWest.Name != "eu-west-1" {
-		t.Errorf("%q != %q", EUWest.Name, "eu-west-1")
+	if EUWest1.Name != "eu-west-1" {
+		t.Errorf("%q != %q", EUWest1.Name, "eu-west-1")
 	}
 	if USWest2.Name != "us-west-2" {
 		t.Errorf("%q != %q", USWest2.Name, "us-west-2")
 	}
-	if USEast.Name != "us-east-1" {
-		t.Errorf("%q != %q", USEast.Name, "us-east-1")
+	if USEast1.Name != "us-east-1" {
+		t.Errorf("%q != %q", USEast1.Name, "us-east-1")
 	}
 }
 


### PR DESCRIPTION
This adds all missing regions that support Kinesis at the moment
(see http://docs.aws.amazon.com/general/latest/gr/rande.html#ak_region)
and additionally applies constant numbering.