### PR TITLE
handle kinesis rate-limiting in example.go

### DIFF
--- a/examples/example.go
+++ b/examples/example.go
@@ -21,6 +21,7 @@ func getRecords(ksis *kinesis.Kinesis, streamName, ShardId string) {
 		args.Add("ShardIterator", shardIterator)
 		resp11, err := ksis.GetRecords(args)
 		if err != nil {
+			time.Sleep(1000 * time.Millisecond)
 			continue
 		}
 

--- a/examples/example.go
+++ b/examples/example.go
@@ -20,6 +20,9 @@ func getRecords(ksis *kinesis.Kinesis, streamName, ShardId string) {
 		args = kinesis.NewArgs()
 		args.Add("ShardIterator", shardIterator)
 		resp11, err := ksis.GetRecords(args)
+		if err != nil {
+			continue
+		}
 
 		if len(resp11.Records) > 0 {
 			fmt.Printf("GetRecords Data BEGIN\n")
@@ -33,6 +36,7 @@ func getRecords(ksis *kinesis.Kinesis, streamName, ShardId string) {
 		}
 
 		shardIterator = resp11.NextShardIterator
+		time.Sleep(1000 * time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
http://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetRecords.html

Note that GetRecords won't return any data when it throws an exception. For this reason, we recommend that you wait one second between calls to GetRecords; however, it's possible that the application will get exceptions for longer than 1 second.