### PR TITLE
Used the kinesis.NewAuth method to ensure env vars are retrieved.

### DIFF
--- a/examples/example.go
+++ b/examples/example.go
@@ -46,7 +46,8 @@ func main() {
 
 	streamName := "test"
 	// set env variables AWS_ACCESS_KEY and AWS_SECRET_KEY AWS_REGION_NAME
-	ksis := kinesis.New(&kinesis.Auth{}, kinesis.Region{})
+	auth := kinesis.NewAuth()
+	ksis := kinesis.New(&auth, kinesis.Region{})
 
 	err := ksis.CreateStream(streamName, 2)
 	if err != nil {


### PR DESCRIPTION
Just a small change to the example.