### PR TITLE
adding the ability to timeout if kinesis doesn't respond in a timely …

### DIFF
--- a/kinesis.go
+++ b/kinesis.go
@@ -60,6 +60,15 @@ func New(auth *Auth, region Region) *Kinesis {
 	return NewWithEndpoint(auth, region, endpoint)
 }
 
+// NewWithTimeout returns an initialized AWS Kinesis client using the canonical live “production” endpoint
+// for AWS Kinesis, i.e. https://kinesis.{region}.amazonaws.com but with the added capability of timing out
+// when Kinesis doesn't respond within the specified timeout
+func NewWithTimeout(auth *Auth, region Region, timeout time.Duration) *Kinesis {
+	endpoint := fmt.Sprintf("https://kinesis.%s.amazonaws.com", GetRegion(region))
+	client := &Client{Auth: auth, Client: &http.Client{Timeout: timeout}}
+	return &Kinesis{client: client, Region: GetRegion(region), endpoint: endpoint}
+}
+
 // NewWithEndpoint returns an initialized AWS Kinesis client using the specified endpoint.
 // This is generally useful for testing, so a local Kinesis server can be used.
 func NewWithEndpoint(auth *Auth, region Region, endpoint string) *Kinesis {


### PR DESCRIPTION
I'd like to introduce the ability to pass in a separate client but this was the simplest form of which the `kinesis.Client` would still be constructed in a convenience constructor. Its similar to the convenience function used for testing for `NewWithEndpoint` but otherwise I'd imagine I would be doing a much larger change.

Here is another idea that I'm more fond of but requires the error handling. Let me know if there is preference for one over the other or if there is another suggestion. I'm also open to suggestions on how to test this.

```go
NewWithClient(client *Client, region Region, timeout time.Duration) (*Kinesis, error) {
  if client.Auth == nil {
    return nil, errors.New("Auth for client must be set")
  }
  endpoint := fmt.Sprintf("https://kinesis.%s.amazonaws.com", GetRegion(region))
  return &Kinesis{client: client, Region: GetRegion(region), endpoint: endpoint}, nil
}
```