### PR TITLE
set Error.Code with the aws json error type

### DIFF
--- a/kinesis.go
+++ b/kinesis.go
@@ -104,6 +104,7 @@ func (err *Error) Error() string {
 }
 
 type jsonErrors struct {
+	Code    string `json:"__type"`
 	Message string
 }
 
@@ -113,6 +114,7 @@ func buildError(r *http.Response) error {
 
 	var err Error
 	err.Message = errors.Message
+	err.Code = errors.Code
 	err.StatusCode = r.StatusCode
 	if err.Message == "" {
 		err.Message = r.Status


### PR DESCRIPTION
Populate the Code field of the json errors so that upstream decisions can be made based on the AWS error class