### PR TITLE
adding version to avoid 400 error

### DIFF
--- a/kinesis.go
+++ b/kinesis.go
@@ -66,7 +66,7 @@ func New(auth *Auth, region Region) *Kinesis {
 func NewWithTimeout(auth *Auth, region Region, timeout time.Duration) *Kinesis {
 	endpoint := fmt.Sprintf("https://kinesis.%s.amazonaws.com", GetRegion(region))
 	client := &Client{Auth: auth, Client: &http.Client{Timeout: timeout}}
-	return &Kinesis{client: client, Region: GetRegion(region), endpoint: endpoint}
+	return &Kinesis{client: client, Version: "20131202", Region: GetRegion(region), endpoint: endpoint}
 }
 
 // NewWithEndpoint returns an initialized AWS Kinesis client using the specified endpoint.


### PR DESCRIPTION
Hey @le0pard , sorry about that. I hadn't thoroughly tested the code previously and accidentally left out the version. Leaving out the version previously produces a 400 error. 

I also had another idea and wonder what you might think about a slight refactor on how the Auth configuration and the Client is handled. I want to propose decoupling the Client's creation to be in a separate constructor than the Kinesis struct. If you're open to that, I could go ahead and try to work on that and get a pull request up for that. It probably won't be backwards compatible too, so a strategy may be needed.