### PR TITLE
Add a retrying background batch producer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
 before_script:
   - kinesalite --createStreamMs 5 --deleteStreamMs 5 &
 
-script: go test
+script: go test -parallel 2
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ You can find a tool for interacting with kinesis from the command line in folder
 
 ## Testing
 
+### Local Kinesis Server
+
 The tests require a local Kinesis server such as [Kinesalite](https://github.com/mhart/kinesalite)
 to be running and reachable at `http://127.0.0.1:4567`.
 
@@ -24,3 +26,8 @@ deletion faster than the default of 500ms, like so:
     kinesalite --createStreamMs 5 --deleteStreamMs 5 &
 
 The `&` runs Kinesalite in the background, which is probably what you want.
+
+### go test
+
+Some of the tests are marked as safe to be run in parallel, so to speed up test execution you might
+want to run `go test` with [the `-parallel n` flag](https://golang.org/cmd/go/#hdr-Description_of_testing_flags).

--- a/batchproducer/batchproducer.go
+++ b/batchproducer/batchproducer.go
@@ -1,0 +1,444 @@
+package batchproducer
+
+import (
+	"errors"
+	"log"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/timehop/go-kinesis"
+)
+
+// MaxKinesisBatchSize is the maximum number of records that Kinesis accepts in a request
+const MaxKinesisBatchSize = 500
+
+// Producer collects records individually and then sends them to Kinesis in
+// batches in the background using PutRecords, with retries.
+// A Producer will do nothing until Start is called.
+type Producer interface {
+	// Start starts the main goroutine. No need to call it using `go`.
+	Start() error
+
+	// Stop signals the main goroutine to finish. Once this is called, Add will immediately start
+	// returning errors (unless and until Start is called again).
+	Stop() error
+
+	// Add might block if the BatchProducer has a buffer and the buffer is full.
+	// In order to prevent filling the buffer and eventually blocking indefinitely,
+	// Add will fail and return an error if the BatchProducer is stopped or stopping. Note
+	// that it’s critical to check the return value because the BatchProducer could have
+	// died in the background due to a panic (or something).
+	Add(data []byte, partitionKey string) error
+
+	// Flush stops the Producer using Stop and attempts to send all buffered records to Kinesis as
+	// fast as possible with batches of size 500 (the maximum). It blocks until either all records
+	// are sent or the timeout expires. It returns the number of records still remaining in the
+	// buffer or (possibly) an error. (It doesn’t currently return errors but that is in the
+	// signature for future-proofing.) A timeout value of 0 means no timeout.
+	// If Flush finishes sending all records without timing out, and sendStats is true, it will
+	// cause a single final StatsBatch to be sent to the StatsReceiver in Config, if set.
+	Flush(timeout time.Duration, sendStats bool) (sent int, remaining int, err error)
+}
+
+// StatReceiver defines an object that can accept stats.
+type StatReceiver interface {
+	// Receive will be called by the main Producer goroutine so it will block all batches from being
+	// sent, so make sure it is either very fast or never blocks at all!
+	Receive(StatsBatch)
+}
+
+// StatsBatch is a kind of a snapshot of activity and happenings. Some of its fields represent
+// "moment-in-time" values e.g. BufferSize is the size of the buffer at the moment the StatsBatch
+// is sent. Other fields are cumulative since the last StatsBatch, i.e. ErrorsSinceLastStat.
+type StatsBatch struct {
+	// Moment-in-time stats
+	BufferSize int
+
+	// Cumulative stats
+	KinesisErrorsSinceLastStat           int
+	RecordsSentSuccessfullySinceLastStat int
+	RecordsDroppedSinceLastStat          int
+}
+
+// BatchingKinesisClient is a subset of KinesisClient to ease mocking.
+type BatchingKinesisClient interface {
+	PutRecords(args *kinesis.RequestArgs) (resp *kinesis.PutRecordsResp, err error)
+}
+
+// Config is a collection of config values for a Producer
+type Config struct {
+	// AddBlocksWhenBufferFull controls the behavior of Add when the buffer is full. If true, Add
+	// will block. If false, Add will return an error. This enables integrating applications to
+	// decide how they want to handle a full buffer e.g. so they can discard records if there’s
+	// a problem.
+	AddBlocksWhenBufferFull bool
+
+	// BatchSize controls the maximum size of the batches sent to Kinesis. If the number of records
+	// in the buffer hits this size, a batch of this size will be sent at that time, regardless of
+	// whether FlushInterval has a value or not.
+	BatchSize int
+
+	// BufferSize is the size of the buffer that stores records before they are sent to the Kinesis
+	// stream. If when Add is called the number of records in the buffer is >= bufferSize then
+	// Add will either block or return an error, depending on the value of AddBlocksWhenBufferFull.
+	BufferSize int
+
+	// FlushInterval controls how often the buffer is flushed to Kinesis. If nonzero, then every
+	// time this interval occurs, if there are any records in the buffer, they will be flushed,
+	// no matter how few there are. The size of the batch that’s flushed may be as small as 1 but
+	// will be no larger than BatchSize.
+	FlushInterval time.Duration
+
+	// The logger used by the Producer.
+	Logger *log.Logger
+
+	// MaxAttemptsPerRecord defines how many attempts should be made for each record before it is
+	// dropped. You probably want this higher than the init default of 0.
+	MaxAttemptsPerRecord int
+
+	// StatInterval will be used to make a *best effort* attempt to send stats *approximately*
+	// when this interval elapses. There’s no guarantee, however, since the main goroutine is
+	// used to send the stats and therefore there may be some skew.
+	StatInterval time.Duration
+
+	// StatReceiver will have its Receive method called approximately every StatInterval.
+	StatReceiver StatReceiver
+}
+
+// DefaultConfig is provided for convenience; if you have no specific preferences on how you’d
+// like to configure your Producer you can pass this into New. The default value of Logger is
+// the same as the standard logger in "log" : `log.New(os.Stderr, "", log.LstdFlags)`.
+var DefaultConfig = Config{
+	AddBlocksWhenBufferFull: false,
+	BufferSize:              10000,
+	FlushInterval:           1 * time.Second,
+	BatchSize:               10,
+	MaxAttemptsPerRecord:    10,
+	StatInterval:            1 * time.Second,
+	Logger:                  log.New(os.Stderr, "", log.LstdFlags),
+}
+
+var (
+	// ErrAlreadyStarted is returned by Start if the Producer is already started.
+	ErrAlreadyStarted = errors.New("already started")
+
+	// ErrAlreadyStopped is returned by Stop if the Producer is already stopped.
+	ErrAlreadyStopped = errors.New("already stopped")
+)
+
+// New creates and returns a BatchProducer that will do nothing until its Start method is called.
+// Once it is started, it will flush a batch to Kinesis whenever either
+// the flushInterval occurs (if flushInterval > 0) or the batchSize is reached,
+// whichever happens first.
+func New(
+	client BatchingKinesisClient,
+	streamName string,
+	config Config,
+) (Producer, error) {
+	if config.BatchSize < 1 || config.BatchSize > MaxKinesisBatchSize {
+		return nil, errors.New("BatchSize must be between 1 and 500 inclusive")
+	}
+
+	if config.BufferSize < config.BatchSize && config.FlushInterval <= 0 {
+		return nil, errors.New("if BufferSize < BatchSize && FlushInterval <= 0 then the buffer will eventually fill up and Add will block forever")
+	}
+
+	if config.FlushInterval > 0 && config.FlushInterval < 50*time.Millisecond {
+		return nil, errors.New("are you crazy")
+	}
+
+	batchProducer := batchProducer{
+		client:      client,
+		streamName:  streamName,
+		config:      config,
+		logger:      config.Logger,
+		currentStat: new(StatsBatch),
+		records:     make(chan batchRecord, config.BufferSize),
+		start:       make(chan interface{}),
+		stop:        make(chan interface{}),
+	}
+
+	return &batchProducer, nil
+}
+
+type batchProducer struct {
+	client            BatchingKinesisClient
+	streamName        string
+	config            Config
+	logger            *log.Logger
+	running           bool
+	runningMu         sync.RWMutex
+	consecutiveErrors int
+	currentDelay      time.Duration
+	currentStat       *StatsBatch
+	records           chan batchRecord
+
+	// start and stop will be unbuffered and will be used to send signals to start/stop and
+	// response signals that indicate that the respective operations have completed.
+	start chan interface{}
+	stop  chan interface{}
+}
+
+type batchRecord struct {
+	data         []byte
+	partitionKey string
+	sendAttempts int
+}
+
+// from/for interface Producer
+func (b *batchProducer) Add(data []byte, partitionKey string) error {
+	if !b.isRunning() {
+		return errors.New("Cannot call Add when BatchProducer is not running (to prevent the buffer filling up and Add blocking indefinitely).")
+	}
+	if b.isBufferFull() && !b.config.AddBlocksWhenBufferFull {
+		return errors.New("Buffer is full")
+	}
+	b.records <- batchRecord{data: data, partitionKey: partitionKey}
+	return nil
+}
+
+// from/for interface Producer
+func (b *batchProducer) Start() error {
+	b.runningMu.Lock()
+	defer b.runningMu.Unlock()
+
+	if b.running {
+		return ErrAlreadyStarted
+	}
+
+	go b.run()
+
+	// We want run to run in the background (in a goroutine) but we don’t want to return until that
+	// goroutine has actually entered its main loop. So we read from this non-buffered channel, which
+	// will block until run writes a value to it.
+	<-b.start
+
+	b.running = true
+
+	return nil
+}
+
+func (b *batchProducer) run() {
+	flushTicker := &time.Ticker{}
+	if b.config.FlushInterval > 0 {
+		flushTicker = time.NewTicker(b.config.FlushInterval)
+		defer flushTicker.Stop()
+	}
+
+	statTicker := &time.Ticker{}
+	if b.config.StatReceiver != nil && b.config.StatInterval > 0 {
+		statTicker = time.NewTicker(b.config.StatInterval)
+		defer statTicker.Stop()
+	}
+
+	// used to signal Start that we are now running (entering the main loop)
+	b.start <- true
+
+	for {
+		select {
+		case <-flushTicker.C:
+			b.sendBatch(b.config.BatchSize)
+		case <-statTicker.C:
+			b.sendStats()
+		case <-b.stop:
+			b.sendStats()
+			b.stop <- true
+			return
+		default:
+			if len(b.records) >= b.config.BatchSize {
+				b.sendBatch(b.config.BatchSize)
+			} else {
+				time.Sleep(1 * time.Millisecond)
+			}
+		}
+	}
+}
+
+// from/for interface Producer
+func (b *batchProducer) Stop() error {
+	b.runningMu.Lock()
+	defer b.runningMu.Unlock()
+
+	if !b.running {
+		return ErrAlreadyStopped
+	}
+
+	// request the main goroutine to stop
+	b.stop <- true
+
+	// block until the main goroutine returns a value indicating that it has stopped
+	<-b.stop
+
+	b.running = false
+
+	return nil
+}
+
+// from/for interface Producer
+// TODO: send all batches in parallel, will require broader refactoring
+func (b *batchProducer) Flush(timeout time.Duration, sendStats bool) (int, int, error) {
+	b.Stop()
+
+	timer := time.NewTimer(timeout)
+	if timeout == 0 {
+		timer.Stop()
+	}
+
+	timedOut := false
+	sent := 0
+
+loop:
+	for len(b.records) > 0 {
+		select {
+		case <-timer.C:
+			timedOut = true
+			break loop
+		default:
+			sent += b.sendBatch(MaxKinesisBatchSize)
+		}
+	}
+
+	if !timedOut && sendStats {
+		b.sendStats()
+	}
+
+	return sent, len(b.records), nil
+}
+
+func (b *batchProducer) isRunning() bool {
+	b.runningMu.RLock()
+	defer b.runningMu.RUnlock()
+	return b.running
+}
+
+// Sends batches of records to Kinesis, possibly re-enqueing them if there are any errors or failed
+// records. Returns the number of records successfully sent, if any.
+func (b *batchProducer) sendBatch(batchSize int) int {
+	if len(b.records) == 0 {
+		return 0
+	}
+
+	// In the future, maybe this could be a RetryPolicy or something
+	if b.consecutiveErrors == 1 {
+		b.currentDelay = 50 * time.Millisecond
+	} else if b.consecutiveErrors > 1 {
+		b.currentDelay *= 2
+	}
+
+	if b.currentDelay > 0 {
+		b.logger.Printf("Delaying the batch by %v because of %v consecutive errors", b.currentDelay, b.consecutiveErrors)
+		time.Sleep(b.currentDelay)
+	}
+
+	records := b.takeRecordsFromBuffer(batchSize)
+	res, err := b.client.PutRecords(b.recordsToArgs(records))
+
+	if err != nil {
+		b.consecutiveErrors++
+		b.currentStat.KinesisErrorsSinceLastStat++
+		b.logger.Printf("Error occurred when sending PutRecords request to Kinesis stream %v: %v", b.streamName, err)
+
+		if b.consecutiveErrors >= 5 && b.isBufferFullOrNearlyFull() {
+			// In order to prevent Add from hanging indefinitely, we start dropping records
+			b.logger.Printf("DROPPING %v records because buffer is full or nearly full and there have been %v consecutive errors from Kinesis", len(records), b.consecutiveErrors)
+		} else {
+			b.logger.Printf("Returning %v records to buffer (%v consecutive errors)", len(records), b.consecutiveErrors)
+			b.returnRecordsToBuffer(records)
+		}
+
+		return 0
+	}
+
+	b.consecutiveErrors = 0
+	b.currentDelay = 0
+	succeeded := len(records) - res.FailedRecordCount
+
+	b.currentStat.RecordsSentSuccessfullySinceLastStat += succeeded
+
+	if res.FailedRecordCount == 0 {
+		b.logger.Printf("PutRecords request succeeded: sent %v records to Kinesis stream %v", succeeded, b.streamName)
+	} else {
+		b.logger.Printf("Partial success when sending a PutRecords request to Kinesis stream %v: %v succeeded, %v failed. Re-enqueueing failed records.", b.streamName, succeeded, res.FailedRecordCount)
+		b.returnSomeFailedRecordsToBuffer(res, records)
+	}
+
+	return succeeded
+}
+
+func (b *batchProducer) isBufferFullOrNearlyFull() bool {
+	return float32(len(b.records))/float32(cap(b.records)) >= 0.95
+}
+
+func (b *batchProducer) isBufferFull() bool {
+	// Treating 99% as full because IIRC, len(chan) has a margin of error
+	return float32(len(b.records))/float32(cap(b.records)) >= 0.99
+}
+
+func (b *batchProducer) takeRecordsFromBuffer(batchSize int) []batchRecord {
+	var size int
+	bufferLen := len(b.records)
+	if bufferLen >= batchSize {
+		size = batchSize
+	} else {
+		size = bufferLen
+	}
+
+	result := make([]batchRecord, size)
+	for i := 0; i < size; i++ {
+		result[i] = <-b.records
+	}
+	return result
+}
+
+func (b *batchProducer) recordsToArgs(records []batchRecord) *kinesis.RequestArgs {
+	args := kinesis.NewArgs()
+	args.Add("StreamName", b.streamName)
+	for _, record := range records {
+		args.AddRecord(record.data, record.partitionKey)
+	}
+	return args
+}
+
+// TODO: perhaps we should use a deque internally as the buffer so we can return records to
+// the front of the queue.
+func (b *batchProducer) returnRecordsToBuffer(records []batchRecord) {
+	for _, record := range records {
+		// Not using b.Add because we want to preserve the value of record.sendAttempts.
+		b.records <- record
+	}
+}
+
+func (b *batchProducer) returnSomeFailedRecordsToBuffer(res *kinesis.PutRecordsResp, records []batchRecord) {
+	for i, result := range res.Records {
+		record := records[i]
+		if result.ErrorCode != "" {
+			record.sendAttempts++
+
+			if record.sendAttempts < b.config.MaxAttemptsPerRecord {
+				b.logger.Printf("Re-enqueueing failed record to buffer for retry. Error code was: '%v' and message was '%v'", result.ErrorCode, result.ErrorMessage)
+				// Not using b.Add because we want to preserve the value of record.sendAttempts.
+				b.records <- record
+			} else {
+				b.currentStat.RecordsDroppedSinceLastStat++
+				msg := "Dropping failed record; it has hit %v attempts " +
+					"which is the maximum. Error code was: '%v' and message was '%v'."
+				b.logger.Printf(msg, record.sendAttempts, result.ErrorCode, result.ErrorMessage)
+			}
+		}
+	}
+}
+
+func (b *batchProducer) sendStats() {
+	if b.config.StatReceiver == nil {
+		return
+	}
+
+	b.currentStat.BufferSize = len(b.records)
+
+	// I considered running this as a goroutine, but I’m concerned about leaks. So instead, for now,
+	// the provider of the BatchStatReceiver must ensure that it is either very fast or non-blocking.
+	b.config.StatReceiver.Receive(*b.currentStat)
+
+	b.currentStat = new(StatsBatch)
+}

--- a/batchproducer/batchproducer_test.go
+++ b/batchproducer/batchproducer_test.go
@@ -1,0 +1,890 @@
+package batchproducer
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/timehop/go-kinesis"
+)
+
+var (
+	discardLogger = log.New(ioutil.Discard, "", 0)
+	stdoutLogger  = log.New(os.Stdout, "", 0)
+)
+
+func TestNewBatchProducerWithGoodValues(t *testing.T) {
+	t.Parallel()
+	config := Config{
+		BufferSize:    10,
+		FlushInterval: 0,
+		BatchSize:     10,
+	}
+	b, err := New(&mockBatchingClient{}, "foo", config)
+	if b == nil {
+		t.Error("b == nil")
+	}
+	if err != nil {
+		t.Errorf("%q != nil", err)
+	}
+}
+
+func TestNewBatchProducerWithBadBatchSize(t *testing.T) {
+	t.Parallel()
+	config := Config{
+		BufferSize:    10000,
+		FlushInterval: 0,
+		BatchSize:     1000,
+	}
+	b, err := New(&mockBatchingClient{}, "foo", config)
+	if b != nil {
+		t.Errorf("%q != nil", b)
+	}
+	if err == nil {
+		t.Error("err == nil")
+	}
+	if !strings.Contains(err.Error(), "between 1 and 500") {
+		t.Errorf("%q does not contain 'between 1 and 500'", err)
+	}
+}
+
+func TestNewBatchProducerWithBadValues(t *testing.T) {
+	t.Parallel()
+	config := Config{
+		BufferSize:    10,
+		FlushInterval: 0,
+		BatchSize:     500,
+	}
+	b, err := New(&mockBatchingClient{}, "foo", config)
+	if b != nil {
+		t.Errorf("%q != nil", b)
+	}
+	if err == nil {
+		t.Fatalf("err == nil")
+	}
+	if !strings.Contains(err.Error(), "Add will block forever") {
+		t.Errorf("%q does not contain 'Add will block forever'", err)
+	}
+}
+
+func TestStart(t *testing.T) {
+	t.Parallel()
+
+	b := newProducer(&mockBatchingClient{}, 10, 0, 10)
+
+	if b.isRunning() {
+		t.Error("b should not be running")
+	}
+
+	err := b.Start()
+	defer b.Stop()
+
+	if err != nil {
+		t.Errorf("%v != nil", err)
+	}
+
+	if !b.isRunning() {
+		t.Error("b should be running")
+	}
+}
+
+func TestStop(t *testing.T) {
+	t.Parallel()
+
+	b := newProducer(&mockBatchingClient{}, 10, 0, 10)
+
+	if b.isRunning() {
+		t.Error("b should not be running")
+	}
+
+	b.Start()
+	err := b.Stop()
+
+	if err != nil {
+		t.Errorf("%v != nil", err)
+	}
+
+	if b.isRunning() {
+		t.Error("b should NOT be running")
+	}
+}
+
+func TestStartWhenStarted(t *testing.T) {
+	t.Parallel()
+	config := Config{
+		BufferSize:    100,
+		FlushInterval: 0,
+		BatchSize:     10,
+	}
+	b, err := New(&mockBatchingClient{}, "foo", config)
+	if err != nil {
+		t.Fatalf("%v != nil", err)
+	}
+
+	b.Start()
+	defer b.Stop()
+
+	err = b.Start()
+	if err == nil {
+		t.Errorf("%v == nil", err)
+	}
+}
+
+func TestStopWhenStopped(t *testing.T) {
+	t.Parallel()
+	config := Config{
+		BufferSize:    100,
+		FlushInterval: 0,
+		BatchSize:     10,
+	}
+	b, err := New(&mockBatchingClient{}, "foo", config)
+	if err != nil {
+		t.Fatalf("%v != nil", err)
+	}
+
+	err = b.Stop()
+	if err == nil {
+		t.Errorf("%v == nil", err)
+	}
+}
+
+func TestSuccessiveStartsAndStops(t *testing.T) {
+	t.Parallel()
+	config := Config{
+		BufferSize:    100,
+		FlushInterval: 0,
+		BatchSize:     10,
+	}
+	b, err := New(&mockBatchingClient{}, "foo", config)
+	if err != nil {
+		t.Fatalf("%v != nil", err)
+	}
+
+	for i := 0; i < 10; i++ {
+		err = b.Start()
+		if err != nil {
+			t.Errorf("%v != nil", err)
+		}
+
+		err = b.Stop()
+		if err != nil {
+			t.Errorf("%v != nil", err)
+		}
+	}
+}
+
+func TestAddRecordWhenStarted(t *testing.T) {
+	t.Parallel()
+	config := Config{
+		BufferSize:    100,
+		FlushInterval: 0,
+		BatchSize:     10,
+	}
+	b, err := New(&mockBatchingClient{}, "foo", config)
+	if err != nil {
+		t.Fatalf("%v != nil", err)
+	}
+
+	b.Start()
+	defer b.Stop()
+
+	err = b.Add([]byte("foo"), "bar")
+	if err != nil {
+		t.Errorf("%v != nil", err)
+	}
+}
+
+func TestAddRecordWhenStopped(t *testing.T) {
+	t.Parallel()
+	config := Config{
+		BufferSize:    100,
+		FlushInterval: 0,
+		BatchSize:     10,
+	}
+	b, err := New(&mockBatchingClient{}, "foo", config)
+	if err != nil {
+		t.Fatalf("%v != nil", err)
+	}
+
+	err = b.Add([]byte("foo"), "bar")
+	if err == nil {
+		t.Errorf("%v == nil", err)
+	}
+}
+
+func TestFlushInterval(t *testing.T) {
+	t.Parallel()
+	c := &mockBatchingClient{}
+	b := newProducer(c, 100, 2*time.Millisecond, 10)
+	b.Start()
+	defer b.Stop()
+
+	b.addRecordsAndWait(10, 0)
+	if len(b.records) != 10 {
+		t.Errorf("%v != 10", len(b.records))
+	}
+	if c.calls != 0 {
+		t.Errorf("%v != 0", c.calls)
+	}
+
+	time.Sleep(3 * time.Millisecond)
+	if len(b.records) != 0 {
+		t.Errorf("%v != 0", len(b.records))
+	}
+	if c.calls != 1 {
+		t.Errorf("%v != 1", c.calls)
+	}
+
+	// 20 more records should result in two more batches being sent
+	b.addRecordsAndWait(20, 8)
+	if len(b.records) != 0 {
+		t.Errorf("%v != 0", len(b.records))
+	}
+	if c.calls != 3 {
+		t.Errorf("%v != 3", c.calls)
+	}
+}
+
+func TestBatchSize(t *testing.T) {
+	t.Parallel()
+	c := &mockBatchingClient{}
+	b := newProducer(c, 100, 0, 5)
+	b.Start()
+	defer b.Stop()
+
+	b.addRecordsAndWait(4, 2)
+	if len(b.records) != 4 {
+		t.Errorf("%v != 4", len(b.records))
+	}
+	if c.calls != 0 {
+		t.Errorf("%v != 0", c.calls)
+	}
+
+	b.addRecordsAndWait(1, 2)
+	if len(b.records) != 0 {
+		t.Errorf("%v != 0", len(b.records))
+	}
+	if c.calls != 1 {
+		t.Errorf("%v != 1", c.calls)
+	}
+
+	b.addRecordsAndWait(6, 2)
+	if len(b.records) != 1 {
+		t.Errorf("%v != 1", len(b.records))
+	}
+	if c.calls != 2 {
+		t.Errorf("%v != 2", c.calls)
+	}
+
+	b.addRecordsAndWait(19, 2)
+	if len(b.records) != 0 {
+		t.Errorf("%v != 0", len(b.records))
+	}
+	if c.calls != 6 {
+		t.Errorf("%v != 6", c.calls)
+	}
+}
+
+func TestBatchError(t *testing.T) {
+	t.Parallel()
+	c := &mockBatchingClient{shouldErr: true}
+	b := newProducer(c, 100, 0, 5)
+	b.Start()
+	defer b.Stop()
+
+	b.addRecordsAndWait(5, 1)
+	if b.consecutiveErrors != 1 {
+		t.Errorf("%v != 1", b.consecutiveErrors)
+	}
+	if len(b.records) != 5 {
+		t.Errorf("%v != 5", len(b.records))
+	}
+
+	// Wait another 55 ms and another error should have occurred
+	time.Sleep(55 * time.Millisecond)
+	if b.consecutiveErrors != 2 {
+		t.Errorf("%v != 2", b.consecutiveErrors)
+	}
+	if len(b.records) != 5 {
+		t.Errorf("%v != 5", len(b.records))
+	}
+
+	b.Stop()
+	b.client = &mockBatchingClient{shouldErr: false}
+	b.Start()
+
+	time.Sleep(205 * time.Millisecond)
+	if b.consecutiveErrors != 0 {
+		t.Errorf("%v != 0", b.consecutiveErrors)
+	}
+	if len(b.records) != 0 {
+		t.Errorf("%v != 0", len(b.records))
+	}
+
+	// This next batch should succeed immediately
+	b.addRecordsAndWait(5, 1)
+	if b.consecutiveErrors != 0 {
+		t.Errorf("%v != 0", b.consecutiveErrors)
+	}
+	if len(b.records) != 0 {
+		t.Errorf("%v != 0", len(b.records))
+	}
+}
+
+func TestBatchPartialFailure(t *testing.T) {
+	t.Parallel()
+	b := newProducer(&mockBatchingClient{}, 100, 0, 20)
+	b.config.MaxAttemptsPerRecord = 2
+	b.Start()
+	defer b.Stop()
+
+	b.addRecordsAndWait(19, 0)
+
+	// Add a single record that will fail. partitionKey is (mis)used to specify that the record
+	// should fail.
+	b.Add([]byte("foo"), "fail")
+
+	// First attempt
+	time.Sleep(1 * time.Millisecond)
+	if len(b.records) != 1 {
+		t.Errorf("%v != 1", len(b.records))
+	}
+
+	// Second attempt
+	b.addRecordsAndWait(19, 1)
+	// The failing record should be thrown away at this point
+	if len(b.records) != 0 {
+		t.Errorf("%v != 0", len(b.records))
+	}
+}
+
+func TestBufferSizeStat(t *testing.T) {
+	t.Parallel()
+
+	sr := &statReceiver{}
+
+	b := newProducer(&mockBatchingClient{}, 100, 0, 20)
+	b.config.StatReceiver = sr
+	b.config.StatInterval = 1 * time.Millisecond
+	b.Start()
+	defer b.Stop()
+
+	// Adding 10 will not trigger a batch
+	b.addRecordsAndWait(10, 2)
+
+	if len(sr.stats) == 0 {
+		// More than one might have been sent, which is fine. We just need at least one.
+		t.Fatalf("%v == 0", len(sr.stats))
+	}
+
+	lastStat := sr.stats[len(sr.stats)-1]
+	if lastStat.BufferSize != 10 {
+		t.Errorf("%v != 10", lastStat.BufferSize)
+	}
+
+	// Adding another 10 **will** trigger a batch
+	b.addRecordsAndWait(10, 2)
+
+	if len(sr.stats) < 2 {
+		t.Fatalf("%v < 2", len(sr.stats))
+	}
+
+	lastStat = sr.stats[len(sr.stats)-1]
+	if lastStat.BufferSize != 0 {
+		t.Errorf("%v != 0", lastStat.BufferSize)
+	}
+}
+
+func TestSuccessfulRecordsStat(t *testing.T) {
+	t.Parallel()
+
+	sr := &statReceiver{}
+	b := newProducer(&mockBatchingClient{}, 100, 0, 20)
+	b.config.StatReceiver = sr
+	b.config.StatInterval = 1 * time.Millisecond
+	// b.logger = stdoutLogger // TEMP TEMP TEMP
+	b.Start()
+	defer b.Stop()
+
+	// Adding 10 will not trigger a batch
+	b.addRecordsAndWait(10, 2)
+
+	if len(sr.stats) == 0 {
+		// More than one might have been sent, which is fine. We just need at least one.
+		t.Fatalf("%v == 0", len(sr.stats))
+	}
+
+	lastStat := sr.stats[len(sr.stats)-1]
+	if lastStat.RecordsSentSuccessfullySinceLastStat != 0 {
+		t.Errorf("%v != 0", lastStat.RecordsSentSuccessfullySinceLastStat)
+	}
+
+	// Adding another 10 **will** trigger a batch
+	b.addRecordsAndWait(10, 2)
+
+	if len(sr.stats) < 2 {
+		t.Fatalf("%v < 2", len(sr.stats))
+	}
+
+	if sr.totalRecordsSentSuccessfully != 20 {
+		t.Errorf("%v != 20", sr.totalRecordsSentSuccessfully)
+	}
+}
+
+func TestSuccessfulRecordsStatWhenSomeRecordsFail(t *testing.T) {
+	t.Parallel()
+
+	sr := &statReceiver{}
+	b := newProducer(&mockBatchingClient{}, 100, 0, 20)
+	b.config.StatReceiver = sr
+	b.config.StatInterval = 1 * time.Millisecond
+	b.config.MaxAttemptsPerRecord = 2
+	b.Start()
+	defer b.Stop()
+
+	b.addRecordsAndWait(19, 0)
+
+	// Add a single record that will fail. partitionKey is (mis)used to specify that the record
+	// should fail.
+	b.Add([]byte("foo"), "fail")
+
+	// Sleep long enough for multiple attempts to be tried
+	time.Sleep(3 * time.Millisecond)
+
+	// Should be 10 because one record failed
+	if sr.totalRecordsSentSuccessfully != 19 {
+		t.Errorf("%v != 19", sr.totalRecordsSentSuccessfully)
+	}
+}
+
+func TestRecordsDroppedStatWhenSomeRecordsFail(t *testing.T) {
+	t.Parallel()
+
+	sr := &statReceiver{}
+	b := newProducer(&mockBatchingClient{}, 100, 0, 20)
+	b.config.StatReceiver = sr
+	b.config.StatInterval = 1 * time.Millisecond
+	b.config.MaxAttemptsPerRecord = 1
+	b.Start()
+	defer b.Stop()
+
+	b.addRecordsAndWait(18, 0)
+
+	// Add two records that will fail. partitionKey is (mis)used to specify that the record
+	// should fail.
+	b.Add([]byte("foo"), "fail")
+	b.Add([]byte("foo"), "fail")
+
+	// Sleep long enough for an attempt to be tried and the stat to be recieved
+	time.Sleep(5 * time.Millisecond)
+
+	if sr.totalRecordsDroppedSinceLastStat != 2 {
+		t.Errorf("%v != 2", sr.totalRecordsDroppedSinceLastStat)
+	}
+}
+
+func TestSuccessfulRecordsStatWhenKinesisReturnsError(t *testing.T) {
+	t.Parallel()
+
+	sr := &statReceiver{}
+	b := newProducer(&mockBatchingClient{shouldErr: true}, 100, 0, 20)
+	b.config.StatReceiver = sr
+	b.config.StatInterval = 1 * time.Millisecond
+	b.Start()
+	defer b.Stop()
+
+	// Adding 20 **will** trigger a batch
+	b.addRecordsAndWait(20, 50)
+
+	if len(sr.stats) < 1 {
+		t.Fatalf("%v < 1", len(sr.stats))
+	}
+
+	// Should be 0 because Kinesis is just returning errors
+	if sr.totalRecordsSentSuccessfully != 0 {
+		t.Errorf("%v != 0", sr.totalRecordsSentSuccessfully)
+	}
+}
+
+func TestKinesisErrorsStatWhenKinesisSucceeds(t *testing.T) {
+	t.Parallel()
+
+	sr := &statReceiver{}
+	b := newProducer(&mockBatchingClient{shouldErr: false}, 100, 0, 20)
+	b.config.StatReceiver = sr
+	b.config.StatInterval = 1 * time.Millisecond
+	b.Start()
+	defer b.Stop()
+
+	// Adding 20 **will** trigger a batch
+	b.addRecordsAndWait(20, 2)
+
+	if len(sr.stats) < 1 {
+		t.Fatalf("%v < 1", len(sr.stats))
+	}
+
+	// Should be 0 because Kinesis is succeeding
+	if sr.totalKinesisErrorsSinceLastStat != 0 {
+		t.Errorf("%v != 0", sr.totalKinesisErrorsSinceLastStat)
+	}
+}
+
+func TestKinesisErrorsStatWhenKinesisReturnsError(t *testing.T) {
+	t.Parallel()
+
+	sr := &statReceiver{}
+	b := newProducer(&mockBatchingClient{shouldErr: true}, 100, 0, 20)
+	b.config.StatReceiver = sr
+	b.config.StatInterval = 1 * time.Millisecond
+	b.Start()
+	defer b.Stop()
+
+	b.addRecordsAndWait(20, 1)
+	b.Stop()
+
+	if sr.totalKinesisErrorsSinceLastStat != 2 {
+		t.Errorf("%v != 2", sr.totalKinesisErrorsSinceLastStat)
+	}
+}
+
+func TestLogMessageWhenKinesisSucceeds(t *testing.T) {
+	t.Parallel()
+
+	b := newProducer(&mockBatchingClient{shouldErr: false}, 100, 0, 20)
+	loggerBuffer, logger := newBufferedLogger()
+	b.logger = logger
+	b.Start()
+	defer b.Stop()
+
+	// Adding 20 **will** trigger a batch
+	b.addRecordsAndWait(20, 2)
+
+	loggerString := loggerBuffer.String()
+	requiredString := "PutRecords request succeeded: sent 20 records to Kinesis stream"
+	if !strings.Contains(loggerString, requiredString) {
+		t.Errorf("%s does not contain %s", loggerString, requiredString)
+	}
+}
+
+func TestLogMessageWhenKinesisReturnsError(t *testing.T) {
+	t.Parallel()
+
+	b := newProducer(&mockBatchingClient{shouldErr: true}, 100, 0, 20)
+	loggerBuffer, logger := newBufferedLogger()
+	b.logger = logger
+	b.Start()
+	defer b.Stop()
+
+	// Adding 20 **will** trigger a batch
+	b.addRecordsAndWait(20, 2)
+
+	loggerString := loggerBuffer.String()
+	requiredString := "Error occurred when sending PutRecords request"
+	if !strings.Contains(loggerString, requiredString) {
+		t.Errorf("%s does not contain %s", loggerString, requiredString)
+	}
+}
+
+func TestLogMessageWhenSomeRecordsFail(t *testing.T) {
+	t.Parallel()
+
+	sr := &statReceiver{}
+	b := newProducer(&mockBatchingClient{}, 100, 2*time.Millisecond, 20)
+	b.config.StatReceiver = sr
+	b.config.StatInterval = 1 * time.Millisecond
+	b.config.MaxAttemptsPerRecord = 2
+	loggerBuffer, logger := newBufferedLogger()
+	b.logger = logger
+	b.Start()
+	defer b.Stop()
+
+	b.addRecordsAndWait(18, 0)
+
+	// Add two records that will fail. partitionKey is (mis)used to specify that the record
+	// should fail.
+	b.Add([]byte("foo"), "fail")
+	b.Add([]byte("foo"), "fail")
+
+	// Sleep long enough for a few attempts to be tried and the failing records to be re-enqueued
+	// and then dropped
+	time.Sleep(5 * time.Millisecond)
+
+	loggerString := loggerBuffer.String()
+
+	requiredString := "Partial success when sending a PutRecords request"
+	if !strings.Contains(loggerString, requiredString) {
+		t.Errorf("%s does not contain %s", loggerString, requiredString)
+	}
+
+	requiredString = "Re-enqueueing failed record to buffer for retry. Error code was: 'foo'"
+	if !strings.Contains(loggerString, requiredString) {
+		t.Errorf("%s does not contain %s", loggerString, requiredString)
+	}
+
+	requiredString = "Dropping failed record; it has hit 2 attempts which is the maximum"
+	if !strings.Contains(loggerString, requiredString) {
+		t.Errorf("%s does not contain %s", loggerString, requiredString)
+	}
+}
+
+func TestAddBlocksFalse(t *testing.T) {
+	t.Parallel()
+
+	b := newProducer(&mockBatchingClient{}, 10, 0, 20)
+	b.Start()
+	defer b.Stop()
+
+	// Adding 10 will fill up the buffer and not trigger a batch
+	b.addRecordsAndWait(10, 2)
+
+	data := []byte("The cheese is old and moldy, where is the bathroom?")
+	partitionKey := "foo"
+	err := b.Add(data, partitionKey)
+
+	if err == nil {
+		t.Errorf("%s == nil", err)
+	}
+}
+
+func TestAddBlocksTrue(t *testing.T) {
+	t.Parallel()
+
+	b := newProducer(&mockBatchingClient{}, 10, 0, 20)
+	b.config.AddBlocksWhenBufferFull = true
+	b.Start()
+	defer b.Stop()
+
+	// Adding 10 will fill up the buffer and not trigger a batch
+	b.addRecordsAndWait(10, 2)
+
+	// This should block so we need to run this in a goroutine
+	go func() {
+		data := []byte("The cheese is old and moldy, where is the bathroom?")
+		partitionKey := "foo"
+		b.Add(data, partitionKey)
+		t.Fatal("We should never have gotten here.")
+	}()
+
+	time.Sleep(1 * time.Millisecond)
+
+	if len(b.records) != 10 {
+		t.Errorf("%v != 10", len(b.records))
+	}
+}
+
+func TestFlush(t *testing.T) {
+	t.Parallel()
+
+	b := newProducer(&mockBatchingClient{}, 20, 0, 20)
+	b.Start()
+	defer b.Stop()
+
+	// Adding 10 will not trigger a batch
+	b.addRecordsAndWait(10, 2)
+
+	timeout := 20 * time.Second
+	sent, remaining, err := b.Flush(timeout, false)
+	if err != nil {
+		t.Errorf("%s != nil", err)
+	}
+
+	if sent != 10 {
+		t.Errorf("%v != 10", sent)
+	}
+	if remaining > 0 {
+		t.Errorf("%v > 0", remaining)
+	}
+	if len(b.records) > 0 {
+		t.Errorf("%v > 0", len(b.records))
+	}
+	if b.isRunning() {
+		t.Errorf("b.running != false")
+	}
+}
+
+func TestFlushWithTimeout(t *testing.T) {
+	t.Parallel()
+
+	c := &mockBatchingClient{
+		sleepFor: 6 * time.Millisecond,
+	}
+	b := newProducer(c, 1000, 0, 10)
+
+	// set running to true so Add will succeed
+	b.running = true
+
+	// Adding 600 will enqueue 2 batches
+	b.addRecordsAndWait(600, 0)
+
+	// back to normal
+	b.running = false
+
+	// This should lead to only 1 batch of 500 being sent by Flush
+	timeout := 5 * time.Millisecond
+
+	start := time.Now()
+	sent, remaining, err := b.Flush(timeout, false)
+	duration := time.Since(start)
+	if err != nil {
+		t.Errorf("%s != nil", err)
+	}
+
+	if sent != 500 {
+		t.Errorf("%v != 500", sent)
+	}
+	if remaining != 100 {
+		t.Errorf("%v != 100", remaining)
+	}
+	if len(b.records) != 100 {
+		t.Errorf("%v != 100", len(b.records))
+	}
+	if duration < 6*time.Millisecond || duration > 8*time.Millisecond {
+		t.Errorf("%v seems off", duration)
+	}
+}
+
+func TestFlushWithoutTimeout(t *testing.T) {
+	t.Parallel()
+
+	c := &mockBatchingClient{
+		sleepFor: 6 * time.Millisecond,
+	}
+	b := newProducer(c, 1000, 0, 10)
+
+	// set running to true so Add will succeed
+	b.running = true
+
+	// Adding 600 will enqueue 2 batches
+	b.addRecordsAndWait(600, 0)
+
+	// back to normal
+	b.running = false
+
+	// This should lead to batches of 500 and 100 being sent by Flush
+	timeout := 0 * time.Millisecond
+
+	start := time.Now()
+	sent, remaining, err := b.Flush(timeout, false)
+	duration := time.Since(start)
+	if err != nil {
+		t.Errorf("%s != nil", err)
+	}
+
+	if sent != 600 {
+		t.Errorf("%v != 600", sent)
+	}
+	if remaining != 0 {
+		t.Errorf("%v != 0", remaining)
+	}
+	if len(b.records) != 0 {
+		t.Errorf("%v != 0", len(b.records))
+	}
+	if duration < 12*time.Millisecond || duration > 16*time.Millisecond {
+		t.Errorf("%v seems off", duration)
+	}
+}
+
+type mockBatchingClient struct {
+	calls     int
+	callsMu   sync.Mutex
+	shouldErr bool
+	numToFail int
+	sleepFor  time.Duration
+}
+
+func (s *mockBatchingClient) PutRecords(args *kinesis.RequestArgs) (resp *kinesis.PutRecordsResp, err error) {
+	s.callsMu.Lock()
+	defer s.callsMu.Unlock()
+	s.calls++
+
+	if s.shouldErr {
+		return nil, errors.New("Oh Noes!")
+	}
+
+	time.Sleep(s.sleepFor)
+
+	res := kinesis.PutRecordsResp{Records: make([]kinesis.PutRecordsRespRecord, len(args.Records))}
+
+	for i, record := range args.Records {
+		if record.PartitionKey == "fail" {
+			res.FailedRecordCount++
+			res.Records[i] = kinesis.PutRecordsRespRecord{ErrorCode: "foo", ErrorMessage: "bar"}
+		} else {
+			res.Records[i] = kinesis.PutRecordsRespRecord{SequenceNumber: "001", ShardId: "001"}
+		}
+	}
+
+	return &res, nil
+}
+
+func newProducer(client *mockBatchingClient, bufferSize int, flushInterval time.Duration, batchSize int) *batchProducer {
+	config := Config{
+		BufferSize: bufferSize,
+		// Set FlushInterval to an interval that will be acceptable to New; we’ll override it below
+		// after calling New.
+		FlushInterval:        50 * time.Millisecond,
+		BatchSize:            batchSize,
+		Logger:               discardLogger,
+		MaxAttemptsPerRecord: 2,
+	}
+
+	producer, err := New(client, "foo", config)
+	if err != nil {
+		panic(err)
+	}
+
+	bp, ok := producer.(*batchProducer)
+	if !ok {
+		panic("producer is not a *batchProducer!")
+	}
+
+	bp.config.FlushInterval = flushInterval
+
+	return bp
+}
+
+// There are some cases wherein immediately after adding the records we want to sleep for some
+// amount of time in order to allow for the batchProducer’s goroutine to do stuff.
+// A possible alternative approach might be to run with multiple CPUs... but that would probably
+// still require waiting for at least some small amount of time. And in fact it would be way
+// less deterministic and less predictable.
+func (b *batchProducer) addRecordsAndWait(numRecords int, millisToWait int) {
+	data := []byte("The cheese is old and moldy, where is the bathroom?")
+	partitionKey := "foo"
+	for i := 0; i < numRecords; i++ {
+		err := b.Add(data, partitionKey)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	if millisToWait > 0 {
+		time.Sleep(time.Duration(millisToWait) * time.Millisecond)
+	}
+}
+
+type statReceiver struct {
+	stats                            []StatsBatch
+	totalKinesisErrorsSinceLastStat  int
+	totalRecordsSentSuccessfully     int
+	totalRecordsDroppedSinceLastStat int
+}
+
+func (s *statReceiver) Receive(sf StatsBatch) {
+	s.stats = append(s.stats, sf)
+	s.totalKinesisErrorsSinceLastStat += sf.KinesisErrorsSinceLastStat
+	s.totalRecordsSentSuccessfully += sf.RecordsSentSuccessfullySinceLastStat
+	s.totalRecordsDroppedSinceLastStat += sf.RecordsDroppedSinceLastStat
+}
+
+func newBufferedLogger() (*bytes.Buffer, *log.Logger) {
+	buf := new(bytes.Buffer)
+	logger := log.New(buf, "", 0)
+	return buf, logger
+}


### PR DESCRIPTION
I need this for a project of mine, and it seemed like it belonged in this library rather than in my application code.

The batch producer:

* Has a single goroutine running in the background
* Uses a channel for buffering and backpressure
* Flushes batches either when a specified batch size is in the buffer or when an optional specified interval occurs
* Accepts a StatReceiver and will regularly send stats to it
* Will retry when HTTP errors occur or are received
* Will retry individual records that fail

The retry behavior in particular is important because Kinesis sometimes returns 500 responses to valid
requests, and [AWS considers this normal](https://forums.aws.amazon.com/thread.jspa?messageID=531831).

For more details see the godoc comments.

Coverage: 96%

We (Timehop) have been using this in production for over a month with good results. For the curious, [here are some slides](https://speakerdeck.com/aviflax/stream-data-processing-with-kinesis-and-go-at-timehop) from a talk I gave on this recently.