### PR TITLE
kinesis-cli now uses the region from the environment

### DIFF
--- a/kinesis-cli/kinesis-cli.go
+++ b/kinesis-cli/kinesis-cli.go
@@ -239,7 +239,7 @@ func bigIntFromStr(s string, base int) *big.Int {
 
 func newClient() kinesis.KinesisClient {
 	auth, _ := kinesis.NewAuthFromEnv()
-	return kinesis.New(auth, "")
+	return kinesis.New(auth, kinesis.NewRegionFromEnv())
 }
 
 func askForShardStartHash(streamName, shardId string) string {


### PR DESCRIPTION
Fix broken kinesis-cli. kinesis-cli was breaking because it was ignoring the AWS_REGION environment variable.