### PR TITLE
#43: Batchproducer imports should use sendgridlabs instead of timehop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
 before_script:
   - kinesalite --createStreamMs 5 --deleteStreamMs 5 &
 
-script: go test -parallel 2
+script: go test ./... -parallel 2
 
 notifications:
   email: false

--- a/batchproducer/batchproducer.go
+++ b/batchproducer/batchproducer.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/timehop/go-kinesis"
+	"github.com/sendgridlabs/go-kinesis"
 )
 
 // MaxKinesisBatchSize is the maximum number of records that Kinesis accepts in a request

--- a/batchproducer/batchproducer_test.go
+++ b/batchproducer/batchproducer_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/timehop/go-kinesis"
+	"github.com/sendgridlabs/go-kinesis"
 )
 
 var (


### PR DESCRIPTION
The batchproducer imports were referencing "timehop" instead of the official release from "sendgridlabs". 

This resulted in my local machine failing to compile w/ the library. 

I am not sure if this is the proper way to handle packages in go and accounting for developers working w/ forks. Any tips would be appreciated if something is wrong.