### PR TITLE
Fix #45: Add support for other AWS key env var names.

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -12,8 +12,10 @@ import (
 )
 
 const (
-	AccessEnvKey = "AWS_ACCESS_KEY"
-	SecretEnvKey = "AWS_SECRET_KEY"
+	AccessEnvKey       = "AWS_ACCESS_KEY"
+	AccessEnvKeyId     = "AWS_ACCESS_KEY_ID"
+	SecretEnvKey       = "AWS_SECRET_KEY"
+	SecretEnvAccessKey = "AWS_SECRET_ACCESS_KEY"
 
 	AWSMetadataServer = "169.254.169.254"
 	AWSIAMCredsPath   = "/latest/meta-data/iam/security-credentials"
@@ -54,12 +56,20 @@ func NewAuth(accessKey, secretKey string) *AuthCredentials {
 // NewAuthFromEnv retrieves auth credentials from environment vars
 func NewAuthFromEnv() (*AuthCredentials, error) {
 	accessKey := os.Getenv(AccessEnvKey)
-	secretKey := os.Getenv(SecretEnvKey)
 	if accessKey == "" {
-		return nil, fmt.Errorf("Unable to retrieve access key from %s env variable", AccessEnvKey)
+		accessKey = os.Getenv(AccessEnvKeyId)
+	}
+
+	secretKey := os.Getenv(SecretEnvKey)
+	if secretKey == "" {
+		secretKey = os.Getenv(SecretEnvAccessKey)
+	}
+
+	if accessKey == "" {
+		return nil, fmt.Errorf("Unable to retrieve access key from %s or %s env variables", AccessEnvKey, AccessEnvKeyId)
 	}
 	if secretKey == "" {
-		return nil, fmt.Errorf("Unable to retrieve secret key from %s env variable", SecretEnvKey)
+		return nil, fmt.Errorf("Unable to retrieve secret key from %s or %s env variables", SecretEnvKey, SecretEnvAccessKey)
 	}
 
 	return NewAuth(accessKey, secretKey), nil

--- a/auth_test.go
+++ b/auth_test.go
@@ -42,6 +42,25 @@ func TestNewAuthFromEnv(t *testing.T) {
 		t.Error("Expected SecretKey to be inferred as \"asdf\"")
 	}
 
+	// Validate that the fallback environment variables will also work
 	os.Setenv(AccessEnvKey, "") // Use Unsetenv with go1.4
 	os.Setenv(SecretEnvKey, "") // Use Unsetenv with go1.4
+}
+
+func TestNewAuthFromEnvWithFallbackVars(t *testing.T) {
+	os.Setenv(AccessEnvKeyId, "asdf")
+	os.Setenv(SecretEnvAccessKey, "asdf")
+
+	auth, _ := NewAuthFromEnv()
+
+	if auth.GetAccessKey() != "asdf" {
+		t.Error("Expected AccessKey to be inferred as \"asdf\"")
+	}
+
+	if auth.GetSecretKey() != "asdf" {
+		t.Error("Expected SecretKey to be inferred as \"asdf\"")
+	}
+
+	os.Setenv(AccessEnvKeyId, "")
+	os.Setenv(SecretEnvAccessKey, "")
 }


### PR DESCRIPTION
Added support for getting the access keys from the following environment variables:

- AWS_ACCESS_KEY_ID
- AWS_SECRET_ACCESS_KEY