### PR TITLE
Quick band-aid to fix a deadlock bug

### DIFF
--- a/batchproducer/batchproducer_test.go
+++ b/batchproducer/batchproducer_test.go
@@ -298,7 +298,7 @@ func TestBatchError(t *testing.T) {
 	b.Start()
 	defer b.Stop()
 
-	b.addRecordsAndWait(5, 1)
+	b.addRecordsAndWait(5, 5)
 	if b.consecutiveErrors != 1 {
 		t.Errorf("%v != 1", b.consecutiveErrors)
 	}
@@ -351,7 +351,7 @@ func TestBatchPartialFailure(t *testing.T) {
 	b.Add([]byte("foo"), "fail")
 
 	// First attempt
-	time.Sleep(1 * time.Millisecond)
+	time.Sleep(5 * time.Millisecond)
 	if len(b.records) != 1 {
 		t.Errorf("%v != 1", len(b.records))
 	}
@@ -545,7 +545,7 @@ func TestKinesisErrorsStatWhenKinesisReturnsError(t *testing.T) {
 	b.Start()
 	defer b.Stop()
 
-	b.addRecordsAndWait(20, 1)
+	b.addRecordsAndWait(20, 5)
 	b.Stop()
 
 	if sr.totalKinesisErrorsSinceLastStat != 2 {


### PR DESCRIPTION
When the buffer is full and 1+ records fail, the attempt to re-enqueue the failed record(s) can block the main background goroutine, essentially deadlocking the entire BatchProducer.

Unfortunately I don’t have time to add a test right now. I’m _fairly_ certain that this should fix the bug, but this fix _might_ end up creating too many goroutines.

The whole package should probably be refactored to use a deque as the buffer, rather than a channel, so that failed records can be re-enqueued back at the head of the queue, so as to preserve ordering, or at least disrupt it less — which is important with Kinesis. In that case (with a deck), we could have one dedicated goroutine managing the deque (accepting new records via a channel and returning records via a channel), discrete and independent of the goroutine that sends records to Kinesis.