### PR TITLE
[BUG] GetRecordsRecords: ApproximateArrivalTimestamp is float, not int

### DIFF
--- a/kinesis.go
+++ b/kinesis.go
@@ -329,7 +329,7 @@ func (kinesis *Kinesis) GetShardIterator(args *RequestArgs) (resp *GetShardItera
 
 // GetNextRecordsRecords stores the information that provides by GetNextRecordsResp
 type GetRecordsRecords struct {
-	ApproximateArrivalTimestamp int64
+	ApproximateArrivalTimestamp float64
 	Data                        []byte
 	PartitionKey                string
 	SequenceNumber              string


### PR DESCRIPTION
Unfortunately the change in #53 was not correct - this value is a float, not an `int`. I was misled by the docs phrasing it this way:

> The timestamp has millisecond precision.

This seems to mean that it's a second, with the three decimal points representing the milliseconds.

I assume the reason it was still passing tests is that `kinesalite` doesn't set the value at all, so it wasn't failing?