### PR TITLE
Fix issue #61 by making AWS security token optional

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -69,14 +69,14 @@ func NewAuthFromEnv() (*AuthCredentials, error) {
 
 	token := os.Getenv(SecurityTokenEnvKey)
 
+	if accessKey == "" && secretKey == "" && token == "" {
+		return nil, fmt.Errorf("No access key (%s or %s), secret key (%s or %s), or security token (%s) env variables were set", AccessEnvKey, AccessEnvKeyId, SecretEnvKey, SecretEnvAccessKey, SecurityTokenEnvKey)
+	}
 	if accessKey == "" {
 		return nil, fmt.Errorf("Unable to retrieve access key from %s or %s env variables", AccessEnvKey, AccessEnvKeyId)
 	}
 	if secretKey == "" {
 		return nil, fmt.Errorf("Unable to retrieve secret key from %s or %s env variables", SecretEnvKey, SecretEnvAccessKey)
-	}
-	if token == "" {
-		return nil, fmt.Errorf("Unable to retrieve security token from %s env variable", SecurityTokenEnvKey)
 	}
 
 	return NewAuth(accessKey, secretKey, token), nil

--- a/auth_test.go
+++ b/auth_test.go
@@ -56,10 +56,48 @@ func TestNewAuthFromEnv(t *testing.T) {
 	}
 
 	if auth.GetToken() != "dummy_token" {
-		t.Error("Expected SecretKey to be inferred as \"dummy_token\"")
+		t.Error("Expected SecurityToken to be inferred as \"dummy_token\"")
 	}
 }
 
+func TestNewAuthFromEnvWithoutSecurityToken(t *testing.T) {
+	os.Setenv(AccessEnvKey, "asdf")
+	os.Setenv(SecretEnvKey, "asdf2")
+	os.Unsetenv(SecurityTokenEnvKey)
+	// Validate that the fallback environment variables will also work
+	defer os.Unsetenv(AccessEnvKey)
+	defer os.Unsetenv(SecretEnvKey)
+
+	auth, _ := NewAuthFromEnv()
+
+	if auth.GetAccessKey() != "asdf" {
+		t.Error("Expected AccessKey to be inferred as \"asdf\"")
+	}
+
+	if auth.GetSecretKey() != "asdf2" {
+		t.Error("Expected SecretKey to be inferred as \"asdf2\"")
+	}
+
+	if auth.GetToken() != "" {
+		t.Error("Expected SecurityToken to be an empty string")
+	}
+}
+
+func TestNewAuthFromEnvWithoutVars(t *testing.T) {
+	os.Unsetenv(AccessEnvKey)
+	os.Unsetenv(SecretEnvKey)
+	os.Unsetenv(SecurityTokenEnvKey)
+
+	auth, err := NewAuthFromEnv()
+
+	if auth != nil {
+		t.Error("Expected auth instance to be nil but was non-nil")
+	}
+
+	if err == nil {
+		t.Error("Expected error to be non-nil but was nil")
+	}
+}
 func TestNewAuthFromEnvWithFallbackVars(t *testing.T) {
 	os.Setenv(AccessEnvKeyId, "asdf")
 	os.Setenv(SecretEnvAccessKey, "asdf2")


### PR DESCRIPTION
The AWS security token ought to be optional when the AWS Access Key ID and Secret Access Key environment variables are both set; instead, the security token is always required.

This PR makes the security-token optional when the AWS Access Key ID and Secret Access Key environment variables are set and non-empty.

Fixes #61 