### PR TITLE
Refactor auth component, add ability to use STS to assume role

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ before_install:
 
 before_script:
   - kinesalite --createStreamMs 5 --deleteStreamMs 5 &
+  - sleep 1
 
 script: go test ./... -parallel 2
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # go-kinesis
+
 [![Build Status](https://travis-ci.org/sendgridlabs/go-kinesis.png?branch=master)](https://travis-ci.org/sendgridlabs/go-kinesis)
 
 GO-lang library for AWS Kinesis API.

--- a/auth.go
+++ b/auth.go
@@ -1,202 +1,23 @@
 package kinesis
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io/ioutil"
-	"net/http"
-	"os"
-	"strings"
 	"time"
 )
 
 const (
-	AccessEnvKey        = "AWS_ACCESS_KEY"
-	AccessEnvKeyId      = "AWS_ACCESS_KEY_ID"
-	SecretEnvKey        = "AWS_SECRET_KEY"
-	SecretEnvAccessKey  = "AWS_SECRET_ACCESS_KEY"
-	SecurityTokenEnvKey = "AWS_SECURITY_TOKEN"
-
-	AWSMetadataServer = "169.254.169.254"
-	AWSIAMCredsPath   = "/latest/meta-data/iam/security-credentials"
-	AWSIAMCredsURL    = "http://" + AWSMetadataServer + "/" + AWSIAMCredsPath
+	AWSSecurityTokenHeader = "X-Amz-Security-Token"
 )
 
 // Auth interface for authentication credentials and information
 type Auth interface {
-	GetToken() string
-	GetExpiration() time.Time
-	GetSecretKey() string
-	GetAccessKey() string
-	HasExpiration() bool
-	Renew() error
-	Sign(*Service, time.Time) []byte
+	// KeyForSigning return an access key / secret / token appropriate for signing at time now,
+	// which as the name suggests, is usually now.
+	KeyForSigning(now time.Time) (*SigningKey, error)
 }
 
-// AuthCredentials holds the AWS credentials and metadata
-type AuthCredentials struct {
-	// accessKey, secretKey are the standard AWS auth credentials
-	accessKey, secretKey, token string
-
-	// expiry indicates the time at which these credentials expire. If this is set
-	// to anything other than the zero value, indicates that the credentials are
-	// temporary (and probably fetched from an IAM role from the metadata server)
-	expiry time.Time
-}
-
-// NewAuth creates a *AuthCredentials struct that adheres to the Auth interface to
-// dynamically retrieve AWS credentials
-func NewAuth(accessKey, secretKey, token string) *AuthCredentials {
-	return &AuthCredentials{
-		accessKey: accessKey,
-		secretKey: secretKey,
-		token:     token,
-	}
-}
-
-// NewAuthFromEnv retrieves auth credentials from environment vars
-func NewAuthFromEnv() (*AuthCredentials, error) {
-	accessKey := os.Getenv(AccessEnvKey)
-	if accessKey == "" {
-		accessKey = os.Getenv(AccessEnvKeyId)
-	}
-
-	secretKey := os.Getenv(SecretEnvKey)
-	if secretKey == "" {
-		secretKey = os.Getenv(SecretEnvAccessKey)
-	}
-
-	token := os.Getenv(SecurityTokenEnvKey)
-
-	if accessKey == "" && secretKey == "" && token == "" {
-		return nil, fmt.Errorf("No access key (%s or %s), secret key (%s or %s), or security token (%s) env variables were set", AccessEnvKey, AccessEnvKeyId, SecretEnvKey, SecretEnvAccessKey, SecurityTokenEnvKey)
-	}
-	if accessKey == "" {
-		return nil, fmt.Errorf("Unable to retrieve access key from %s or %s env variables", AccessEnvKey, AccessEnvKeyId)
-	}
-	if secretKey == "" {
-		return nil, fmt.Errorf("Unable to retrieve secret key from %s or %s env variables", SecretEnvKey, SecretEnvAccessKey)
-	}
-
-	return NewAuth(accessKey, secretKey, token), nil
-}
-
-// NewAuthFromMetadata retrieves auth credentials from the metadata
-// server. If an IAM role is associated with the instance we are running on, the
-// metadata server will expose credentials for that role under a known endpoint.
-//
-// TODO: specify custom network (connect, read) timeouts, else this will block
-// for the default timeout durations.
-func NewAuthFromMetadata() (*AuthCredentials, error) {
-	auth := &AuthCredentials{}
-	if err := auth.Renew(); err != nil {
-		return nil, err
-	}
-	return auth, nil
-}
-
-// HasExpiration returns true if the expiration time is non-zero and false otherwise
-func (a *AuthCredentials) HasExpiration() bool {
-	return !a.expiry.IsZero()
-}
-
-// GetExpiration retrieves the current expiration time
-func (a *AuthCredentials) GetExpiration() time.Time {
-	return a.expiry
-}
-
-// GetToken returns the token
-func (a *AuthCredentials) GetToken() string {
-	return a.token
-}
-
-// GetSecretKey returns the secret key
-func (a *AuthCredentials) GetSecretKey() string {
-	return a.secretKey
-}
-
-// GetAccessKey returns the access key
-func (a *AuthCredentials) GetAccessKey() string {
-	return a.accessKey
-}
-
-// Renew retrieves a new token and mutates it on an instance of the Auth struct
-func (a *AuthCredentials) Renew() error {
-	role, err := retrieveIAMRole()
-	if err != nil {
-		return err
-	}
-
-	data, err := retrieveAWSCredentials(role)
-	if err != nil {
-		return err
-	}
-
-	// Ignore the error, it just means we won't be able to refresh the
-	// credentials when they expire.
-	expiry, _ := time.Parse(time.RFC3339, data["Expiration"])
-
-	a.expiry = expiry
-	a.accessKey = data["AccessKeyId"]
-	a.secretKey = data["SecretAccessKey"]
-	a.token = data["Token"]
-	return nil
-}
-
-// Sign API request by
-// http://docs.amazonwebservices.com/general/latest/gr/signature-version-4.html
-
-func (a *AuthCredentials) Sign(s *Service, t time.Time) []byte {
-	h := ghmac([]byte("AWS4"+a.GetSecretKey()), []byte(t.Format(iSO8601BasicFormatShort)))
-	h = ghmac(h, []byte(s.Region))
-	h = ghmac(h, []byte(s.Name))
-	h = ghmac(h, []byte(AWS4_URL))
-	return h
-}
-
-func retrieveAWSCredentials(role string) (map[string]string, error) {
-	var bodybytes []byte
-	// Retrieve the json for this role
-	resp, err := http.Get(fmt.Sprintf("%s/%s", AWSIAMCredsURL, role))
-	if err != nil || resp.StatusCode != http.StatusOK {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	bodybytes, err = ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	jsondata := make(map[string]string)
-	err = json.Unmarshal(bodybytes, &jsondata)
-	if err != nil {
-		return nil, err
-	}
-
-	return jsondata, nil
-}
-
-func retrieveIAMRole() (string, error) {
-	var bodybytes []byte
-
-	resp, err := http.Get(AWSIAMCredsURL)
-	if err != nil || resp.StatusCode != http.StatusOK {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	bodybytes, err = ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
-
-	// pick the first IAM role
-	role := strings.Split(string(bodybytes), "\n")[0]
-	if len(role) == 0 {
-		return "", errors.New("Unable to retrieve IAM role")
-	}
-
-	return role, nil
+// SigningKey returns a set of data needed for signing
+type SigningKey struct {
+	AccessKeyId     string
+	SecretAccessKey string
+	SessionToken    string
 }

--- a/auth_assumerole.go
+++ b/auth_assumerole.go
@@ -1,0 +1,86 @@
+package kinesis
+
+import (
+	"bytes"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// NewAuthWithAssumedRole will call STS in a given region to assume a role
+// stsAuth object is used to authenticate to STS to fetch temporary credentials
+// for the desired role.
+func NewAuthWithAssumedRole(roleArn, sessionName, region string, stsAuth Auth) (Auth, error) {
+	return newCachedMutexedWarmedUpAuth(&stsCreds{
+		RoleARN:     roleArn,
+		SessionName: sessionName,
+		Region:      region,
+		STSAuth:     stsAuth,
+	})
+}
+
+type stsCreds struct {
+	RoleARN     string
+	SessionName string
+	Region      string
+	STSAuth     Auth
+}
+
+func (sts *stsCreds) ExpiringKeyForSigning(now time.Time) (*SigningKey, time.Time, error) {
+	r, err := http.NewRequest(http.MethodPost, fmt.Sprintf("https://sts.%s.amazonaws.com/?%s", sts.Region, (url.Values{
+		"Version":         []string{"2011-06-15"},
+		"Action":          []string{"AssumeRole"},
+		"RoleSessionName": []string{sts.SessionName},
+		"RoleArn":         []string{sts.RoleARN},
+	}).Encode()), bytes.NewReader([]byte{}))
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+
+	err = (&Service{
+		Name:   "sts",
+		Region: sts.Region,
+	}).Sign(sts.STSAuth, r)
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+
+	resp, err := http.DefaultClient.Do(r)
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, time.Time{}, errors.New("bad status code")
+	}
+
+	var wrapper struct {
+		AssumeRoleResult struct {
+			Credentials struct {
+				AccessKeyId     string
+				SecretAccessKey string
+				SessionToken    string
+				Expiration      time.Time
+			}
+		}
+	}
+	err = xml.NewDecoder(resp.Body).Decode(&wrapper)
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+
+	// sanity check at least 1 field
+	if wrapper.AssumeRoleResult.Credentials.SecretAccessKey == "" {
+		return nil, time.Time{}, errors.New("bad data back")
+	}
+
+	return &SigningKey{
+		AccessKeyId:     wrapper.AssumeRoleResult.Credentials.AccessKeyId,
+		SecretAccessKey: wrapper.AssumeRoleResult.Credentials.SecretAccessKey,
+		SessionToken:    wrapper.AssumeRoleResult.Credentials.SessionToken,
+	}, wrapper.AssumeRoleResult.Credentials.Expiration, nil
+}

--- a/auth_cachedmutexedwarmedup.go
+++ b/auth_cachedmutexedwarmedup.go
@@ -1,0 +1,53 @@
+package kinesis
+
+import (
+	"sync"
+	"time"
+)
+
+// newCachedMutexedWarmedUpAuth wraps another auth object
+// with a cache that is thread-safe, and will always attempt
+// to fetch credentials when initialised.
+// The underlying Auth object will only be called if the time is
+// past the last returned expiration time.
+func newCachedMutexedWarmedUpAuth(underlying temporaryCredentialGenerator) (Auth, error) {
+	rv := &cachedMutexedAuth{
+		underlying: underlying,
+	}
+	_, err := rv.KeyForSigning(time.Now())
+	if err != nil {
+		return nil, err
+	}
+	return rv, nil
+}
+
+// Auth interface for authentication credentials and information
+type temporaryCredentialGenerator interface {
+	// KeyForSigning return an access key / secret / token appropriate for signing at time now,
+	// which as the name suggests, is usually now.
+	// Additionally returns the expriration time of these credentials.
+	ExpiringKeyForSigning(now time.Time) (*SigningKey, time.Time, error)
+}
+
+type cachedMutexedAuth struct {
+	mu         sync.Mutex
+	current    *SigningKey
+	expiration time.Time
+	underlying temporaryCredentialGenerator
+}
+
+func (cmuxa *cachedMutexedAuth) KeyForSigning(now time.Time) (*SigningKey, error) {
+	cmuxa.mu.Lock()
+	defer cmuxa.mu.Unlock()
+
+	if cmuxa.current == nil || !cmuxa.expiration.After(now) {
+		newCurrent, newExpiration, err := cmuxa.underlying.ExpiringKeyForSigning(now)
+		if err != nil {
+			return nil, err
+		}
+		cmuxa.current = newCurrent
+		cmuxa.expiration = newExpiration
+	}
+
+	return cmuxa.current, nil
+}

--- a/auth_metadata.go
+++ b/auth_metadata.go
@@ -1,0 +1,98 @@
+package kinesis
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	AWSMetadataServer = "169.254.169.254"
+	AWSIAMCredsPath   = "/latest/meta-data/iam/security-credentials"
+	AWSIAMCredsURL    = "http://" + AWSMetadataServer + "/" + AWSIAMCredsPath
+)
+
+// NewAuthFromMetadata retrieves auth credentials from the metadata
+// server. If an IAM role is associated with the instance we are running on, the
+// metadata server will expose credentials for that role under a known endpoint.
+//
+// TODO: specify custom network (connect, read) timeouts, else this will block
+// for the default timeout durations.
+func NewAuthFromMetadata() (Auth, error) {
+	return newCachedMutexedWarmedUpAuth(&metadataCreds{})
+}
+
+type metadataCreds struct{}
+
+func (mc *metadataCreds) ExpiringKeyForSigning(now time.Time) (*SigningKey, time.Time, error) {
+	role, err := retrieveIAMRole()
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+
+	data, err := retrieveAWSCredentials(role)
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+
+	expiry, err := time.Parse(time.RFC3339, data["Expiration"])
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+
+	return &SigningKey{
+		AccessKeyId:     data["AccessKeyId"],
+		SecretAccessKey: data["SecretAccessKey"],
+		SessionToken:    data["Token"],
+	}, expiry, nil
+}
+
+func retrieveAWSCredentials(role string) (map[string]string, error) {
+	var bodybytes []byte
+	// Retrieve the json for this role
+	resp, err := http.Get(fmt.Sprintf("%s/%s", AWSIAMCredsURL, role))
+	if err != nil || resp.StatusCode != http.StatusOK {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	bodybytes, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	jsondata := make(map[string]string)
+	err = json.Unmarshal(bodybytes, &jsondata)
+	if err != nil {
+		return nil, err
+	}
+
+	return jsondata, nil
+}
+
+func retrieveIAMRole() (string, error) {
+	var bodybytes []byte
+
+	resp, err := http.Get(AWSIAMCredsURL)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	bodybytes, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	// pick the first IAM role
+	role := strings.Split(string(bodybytes), "\n")[0]
+	if len(role) == 0 {
+		return "", errors.New("Unable to retrieve IAM role")
+	}
+
+	return role, nil
+}

--- a/auth_static.go
+++ b/auth_static.go
@@ -1,0 +1,62 @@
+package kinesis
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+const (
+	AccessEnvKey        = "AWS_ACCESS_KEY"
+	AccessEnvKeyId      = "AWS_ACCESS_KEY_ID"
+	SecretEnvKey        = "AWS_SECRET_KEY"
+	SecretEnvAccessKey  = "AWS_SECRET_ACCESS_KEY"
+	SecurityTokenEnvKey = "AWS_SECURITY_TOKEN"
+)
+
+// NewAuth creates return an auth object that uses static
+// credentials which do not automatically renew.
+func NewAuth(accessKey, secretKey, token string) Auth {
+	return &staticAuth{
+		staticCreds: &SigningKey{
+			AccessKeyId:     accessKey,
+			SecretAccessKey: secretKey,
+			SessionToken:    token,
+		},
+	}
+}
+
+// NewAuthFromEnv retrieves auth credentials from environment vars
+func NewAuthFromEnv() (Auth, error) {
+	accessKey := os.Getenv(AccessEnvKey)
+	if accessKey == "" {
+		accessKey = os.Getenv(AccessEnvKeyId)
+	}
+
+	secretKey := os.Getenv(SecretEnvKey)
+	if secretKey == "" {
+		secretKey = os.Getenv(SecretEnvAccessKey)
+	}
+
+	token := os.Getenv(SecurityTokenEnvKey)
+
+	if accessKey == "" && secretKey == "" && token == "" {
+		return nil, fmt.Errorf("No access key (%s or %s), secret key (%s or %s), or security token (%s) env variables were set", AccessEnvKey, AccessEnvKeyId, SecretEnvKey, SecretEnvAccessKey, SecurityTokenEnvKey)
+	}
+	if accessKey == "" {
+		return nil, fmt.Errorf("Unable to retrieve access key from %s or %s env variables", AccessEnvKey, AccessEnvKeyId)
+	}
+	if secretKey == "" {
+		return nil, fmt.Errorf("Unable to retrieve secret key from %s or %s env variables", SecretEnvKey, SecretEnvAccessKey)
+	}
+
+	return NewAuth(accessKey, secretKey, token), nil
+}
+
+type staticAuth struct {
+	staticCreds *SigningKey
+}
+
+func (sc *staticAuth) KeyForSigning(now time.Time) (*SigningKey, error) {
+	return sc.staticCreds, nil
+}

--- a/auth_test.go
+++ b/auth_test.go
@@ -3,35 +3,29 @@ package kinesis
 import (
 	"os"
 	"testing"
+	"time"
 )
-
-func TestAuthInterfaceIsImplemented(t *testing.T) {
-	var auth Auth = &AuthCredentials{}
-	if auth == nil {
-		t.Error("Invalid nil auth credentials value")
-	}
-}
 
 func TestGetSecretKey(t *testing.T) {
 	auth := NewAuth("BAD_ACCESS_KEY", "BAD_SECRET_KEY", "BAD_SECURITY_TOKEN")
-
-	if auth.GetAccessKey() != "BAD_ACCESS_KEY" {
+	sk, _ := auth.KeyForSigning(time.Now())
+	if sk.AccessKeyId != "BAD_ACCESS_KEY" {
 		t.Error("incorrect value for auth#accessKey")
 	}
 }
 
 func TestGetAccessKey(t *testing.T) {
 	auth := NewAuth("BAD_ACCESS_KEY", "BAD_SECRET_KEY", "BAD_SECURITY_TOKEN")
-
-	if auth.GetSecretKey() != "BAD_SECRET_KEY" {
+	sk, _ := auth.KeyForSigning(time.Now())
+	if sk.SecretAccessKey != "BAD_SECRET_KEY" {
 		t.Error("incorrect value for auth#secretKey")
 	}
 }
 
 func TestGetToken(t *testing.T) {
 	auth := NewAuth("BAD_ACCESS_KEY", "BAD_SECRET_KEY", "BAD_SECURITY_TOKEN")
-
-	if auth.GetToken() != "BAD_SECURITY_TOKEN" {
+	sk, _ := auth.KeyForSigning(time.Now())
+	if sk.SessionToken != "BAD_SECURITY_TOKEN" {
 		t.Error("incorrect value for auth#token")
 	}
 }
@@ -46,16 +40,17 @@ func TestNewAuthFromEnv(t *testing.T) {
 	defer os.Unsetenv(SecurityTokenEnvKey)
 
 	auth, _ := NewAuthFromEnv()
+	sk, _ := auth.KeyForSigning(time.Now())
 
-	if auth.GetAccessKey() != "asdf" {
+	if sk.AccessKeyId != "asdf" {
 		t.Error("Expected AccessKey to be inferred as \"asdf\"")
 	}
 
-	if auth.GetSecretKey() != "asdf2" {
+	if sk.SecretAccessKey != "asdf2" {
 		t.Error("Expected SecretKey to be inferred as \"asdf2\"")
 	}
 
-	if auth.GetToken() != "dummy_token" {
+	if sk.SessionToken != "dummy_token" {
 		t.Error("Expected SecurityToken to be inferred as \"dummy_token\"")
 	}
 }
@@ -69,16 +64,17 @@ func TestNewAuthFromEnvWithoutSecurityToken(t *testing.T) {
 	defer os.Unsetenv(SecretEnvKey)
 
 	auth, _ := NewAuthFromEnv()
+	sk, _ := auth.KeyForSigning(time.Now())
 
-	if auth.GetAccessKey() != "asdf" {
+	if sk.AccessKeyId != "asdf" {
 		t.Error("Expected AccessKey to be inferred as \"asdf\"")
 	}
 
-	if auth.GetSecretKey() != "asdf2" {
+	if sk.SecretAccessKey != "asdf2" {
 		t.Error("Expected SecretKey to be inferred as \"asdf2\"")
 	}
 
-	if auth.GetToken() != "" {
+	if sk.SessionToken != "" {
 		t.Error("Expected SecurityToken to be an empty string")
 	}
 }
@@ -107,12 +103,13 @@ func TestNewAuthFromEnvWithFallbackVars(t *testing.T) {
 	defer os.Unsetenv(SecurityTokenEnvKey)
 
 	auth, _ := NewAuthFromEnv()
+	sk, _ := auth.KeyForSigning(time.Now())
 
-	if auth.GetAccessKey() != "asdf" {
+	if sk.AccessKeyId != "asdf" {
 		t.Error("Expected AccessKey to be inferred as \"asdf\"")
 	}
 
-	if auth.GetSecretKey() != "asdf2" {
+	if sk.SecretAccessKey != "asdf2" {
 		t.Error("Expected SecretKey to be inferred as \"asdf2\"")
 	}
 }

--- a/client.go
+++ b/client.go
@@ -2,10 +2,7 @@ package kinesis
 
 import (
 	"net/http"
-	"time"
 )
-
-const AWSSecurityTokenHeader = "X-Amz-Security-Token"
 
 // Client is like http.Client, but signs all requests using Auth.
 type Client struct {
@@ -37,16 +34,6 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	err := Sign(c.auth, req)
 	if err != nil {
 		return nil, err
-	}
-
-	if c.auth.HasExpiration() && time.Now().After(c.auth.GetExpiration()) {
-		if err = c.auth.Renew(); err != nil { // TODO: (see auth.go#Renew) may be slow
-			return nil, err
-		}
-	}
-
-	if c.auth.GetToken() != "" {
-		req.Header.Add(AWSSecurityTokenHeader, c.auth.GetToken())
 	}
 
 	return c.client.Do(req)

--- a/sign_test.go
+++ b/sign_test.go
@@ -14,22 +14,22 @@ var testSignFactoryData = []struct {
 	AuthHeader string
 }{
 	{"ASWKEY", "AWSSECRET", "TOKEN1", "Thu, 28 Nov 2013 15:04:05 GMT", "AWS4-HMAC-SHA256 Credential=ASWKEY/20131128/us-east-1/kinesis/aws4_request, SignedHeaders=content-type;date;host;user-agent;x-amz-target, Signature=6c21aca39f1d4afd383fbc45dd3a580192036162f74bf9fda6cad6c6fb7cde2f"},
-	{"ASWKEY2", "AWSSECRET2", "TOKEN2", "Thu, 28 Nov 2013 15:04:05 GMT", "AWS4-HMAC-SHA256 Credential=ASWKEY2/20131128/us-east-1/kinesis/aws4_request, SignedHeaders=authorization;content-type;date;host;user-agent;x-amz-target, Signature=0b442a629ffe0a405f718f8e50ffdbe3886574687fe3d60dffcc09d67e4aff5a"},
-	{"ASWNEWKEY", "AWSSECRET", "TOKEN3", "Thu, 28 Nov 2013 15:04:05 GMT", "AWS4-HMAC-SHA256 Credential=ASWNEWKEY/20131128/us-east-1/kinesis/aws4_request, SignedHeaders=authorization;content-type;date;host;user-agent;x-amz-target, Signature=f92bd23b4e9f6163779c93dee8b34c673ae394f934b4562dcebfdf4adef9685e"},
-	{"ASWKEY", "AWSSECRET", "TOKEN4", "Mon, 25 Nov 2013 15:04:05 GMT", "AWS4-HMAC-SHA256 Credential=ASWKEY/20131125/us-east-1/kinesis/aws4_request, SignedHeaders=authorization;content-type;date;host;user-agent;x-amz-target, Signature=cabe7376fd1b308e8fda031be50a013509dba601445573c5527c1be205c59fa5"},
+	{"ASWKEY2", "AWSSECRET2", "TOKEN2", "Thu, 28 Nov 2013 15:04:05 GMT", "AWS4-HMAC-SHA256 Credential=ASWKEY2/20131128/us-east-1/kinesis/aws4_request, SignedHeaders=content-type;date;host;user-agent;x-amz-target, Signature=488ee09d2d56e747beb5653064d7976cb67136a2afa6013d82ff36d6ae95d263"},
+	{"ASWNEWKEY", "AWSSECRET", "TOKEN3", "Thu, 28 Nov 2013 15:04:05 GMT", "AWS4-HMAC-SHA256 Credential=ASWNEWKEY/20131128/us-east-1/kinesis/aws4_request, SignedHeaders=content-type;date;host;user-agent;x-amz-target, Signature=6c21aca39f1d4afd383fbc45dd3a580192036162f74bf9fda6cad6c6fb7cde2f"},
+	{"ASWKEY", "AWSSECRET", "TOKEN4", "Mon, 25 Nov 2013 15:04:05 GMT", "AWS4-HMAC-SHA256 Credential=ASWKEY/20131125/us-east-1/kinesis/aws4_request, SignedHeaders=content-type;date;host;user-agent;x-amz-target, Signature=cec25de1e72db69dd48ff4895dc4022e31dc5933209d5bce61286779d49a95e5"},
 }
 
 func TestSign(t *testing.T) {
-	request, err := http.NewRequest("POST", "https://kinesis.us-east-1.amazonaws.com", strings.NewReader("{}"))
-	if err != nil {
-		t.Errorf("NewRequest Error %v", err)
-	}
-
-	request.Header.Set("Content-Type", "application/x-amz-json-1.1")
-	request.Header.Set("X-Amz-Target", "")
-	request.Header.Set("User-Agent", "Golang Kinesis")
-
 	for _, data := range testSignFactoryData {
+		request, err := http.NewRequest("POST", "https://kinesis.us-east-1.amazonaws.com", strings.NewReader("{}"))
+		if err != nil {
+			t.Errorf("NewRequest Error %v", err)
+		}
+
+		request.Header.Set("Content-Type", "application/x-amz-json-1.1")
+		request.Header.Set("X-Amz-Target", "")
+		request.Header.Set("User-Agent", "Golang Kinesis")
+
 		request.Header.Set("Date", data.DateHeader)
 		err = Sign(NewAuth(data.AWS_KEY, data.AWS_SECRET, data.TOKEN), request)
 		if err != nil {


### PR DESCRIPTION
We'd like to be able to use our IAM instance profile to assume a role (in another account) and use that to communicate with Kinesis.

This PR changes the interface for `Auth` to only needing to a set of credentials that can be used together for signing. By returning this as one object it means the `Auth` implementation can be responsible for ensuring the credentials are fresh enough for us if they are ones that expire.

We are now able to assume an STS role as follows in our code:

```golang
func NewKinesisProducer(options KinesisOptions) (batchproducer.Producer, error) {
	var err error
	var kinAuth kinesis.Auth
	if options.AWSAccessKey == "" {
		kinAuth, err = kinesis.NewAuthFromMetadata()
		if err != nil {
			return nil, err
		}
	} else {
		kinAuth = kinesis.NewAuth(options.AWSAccessKey, options.AWSAccessSecret, "")
	}

	// assume role if needed
	if options.AWSRole != "" {
		kinAuth, err = kinesis.NewAuthWithAssumedRole(options.AWSRole, options.AWSSessionName, options.AWSRegion, kinAuth)
		if err != nil {
			return nil, err
		}
	}

	bpCB := &bpCallback{
		options: &options,
	}
	kinBP, err := batchproducer.New(kinesis.NewWithClient(options.AWSRegion, kinesis.NewClient(kinAuth)), options.AWSStreamName, batchproducer.Config{
		AddBlocksWhenBufferFull: true,
		BatchSize:               batchproducer.MaxKinesisBatchSize,
		BufferSize:              batchproducer.MaxKinesisBatchSize * 10,
		FlushInterval:           5 * time.Second,
		MaxAttemptsPerRecord:    5,
		Logger:                  bpCB,
		StatInterval:            5 * time.Second,
		StatReceiver:            bpCB,
	})
	if err != nil {
		return nil, err
	}
	return kinBP, nil
}
```

(full app: <https://github.com/govau/cga-logs-to-kinesis/blob/master/src/logs-to-kinesis/main.go>)

Including all of this in one `auth.go` file was getting large, so split it into several files, which makes this PR look bigger than it really is.

This also fixes what appears to be some bugs in the tests - the same request object was mutated in a loop of what should have been independent tests.