### PR TITLE
Fix example. Include region to kinesis.New, so code properly runs

### DIFF
--- a/examples/example.go
+++ b/examples/example.go
@@ -57,7 +57,8 @@ func main() {
 		fmt.Printf("Unable to retrieve authentication credentials from the environment: %v", err)
 		os.Exit(1)
 	}
-	ksis := kinesis.New(auth, "")
+	region := os.Getenv("AWS_REGION_NAME")
+	ksis := kinesis.New(auth, region)
 
 	err = ksis.CreateStream(streamName, 2)
 	if err != nil {


### PR DESCRIPTION
Now if I run example.go file, i will get unexpected errors like: 

`CreateStream ERROR: Post https://kinesis..amazonaws.com: dial tcp: lookup kinesis..amazonaws.com: no such host
ListStreams: <nil>
DescribeStream: <nil>
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x64d473]

goroutine 1 [running]:
main.main()
	/home/anatoliy/go/src/github.com/triggermesh/sources/awskinesis/main.go:47 +0x4c3
exit status 2
`

This PR fixes these errors, since there is a note that we should set up env var for region, in fact it is never used in the code. When I add it, everything worked. So, I think you need to include that in the code so that future users would not spend their time figuring out the error. 