### PR TITLE
Fix AWS authentication using metdata timeout.  Default HTTP client ha…

### DIFF
--- a/auth_metadata.go
+++ b/auth_metadata.go
@@ -53,8 +53,13 @@ func (mc *metadataCreds) ExpiringKeyForSigning(now time.Time) (*SigningKey, time
 
 func retrieveAWSCredentials(role string) (map[string]string, error) {
 	var bodybytes []byte
+
+	client := http.Client{
+		Timeout: time.Duration(10 * time.Second),
+	}
+
 	// Retrieve the json for this role
-	resp, err := http.Get(fmt.Sprintf("%s/%s", AWSIAMCredsURL, role))
+	resp, err := client.Get(fmt.Sprintf("%s/%s", AWSIAMCredsURL, role))
 	if err != nil || resp.StatusCode != http.StatusOK {
 		return nil, err
 	}
@@ -77,7 +82,11 @@ func retrieveAWSCredentials(role string) (map[string]string, error) {
 func retrieveIAMRole() (string, error) {
 	var bodybytes []byte
 
-	resp, err := http.Get(AWSIAMCredsURL)
+	client := http.Client{
+		Timeout: time.Duration(10 * time.Second),
+	}
+
+	resp, err := client.Get(AWSIAMCredsURL)
 	if err != nil || resp.StatusCode != http.StatusOK {
 		return "", err
 	}


### PR DESCRIPTION
The net/http default client uses 0 as the time out value.  This results in requests hanging forever if the end point is not available.

I am writing something that uses this library in both an AWS environment where the metadata service is available and environments where it is not.  To handle this, the request should time out (resulting in and error) if the service is not available.